### PR TITLE
FIX: jwt Auth struct field 

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -16,7 +16,7 @@ type Auth struct {
 	Email      string      `json:"email"`
 	Username   string      `json:"username"`
 	Role       string      `json:"role"`
-	ReferralID string      `json:"referral_id"`
+	ReferralID json.Number `json:"referral_id"`
 	Level      json.Number `json:"level"`
 	Audience   []string    `json:"aud,omitempty"`
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -70,4 +70,15 @@ func TestAuth_JWT(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("should validate jwt with referral_id", func(t *testing.T) {
+		token, err := ForgeToken("uid", "email", "role", 3, ks.PrivateKey, jwt.MapClaims{"referral_id": 3})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = ParseAndValidate(token, ks.PublicKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }


### PR DESCRIPTION
Hi 
I notice that barong sign the jwt with the referral_id field as a number instead of a string
in my stack the jwt package is not able to unmarshal the json because of that.
Please let me know if this is a version problem or a bug